### PR TITLE
Moved fix from my_ama to exact_target gem

### DIFF
--- a/lib/exact_target/subscription_manager.rb
+++ b/lib/exact_target/subscription_manager.rb
@@ -41,7 +41,7 @@ module ExactTarget
     end
 
     def build_subscription(email, args)
-      if args[:error].nil?
+      if args && args[:error].nil?
         params = { email: args[:Email__Address],
                    travel_weekly: args[:AMA__TRAVEL__Weekly],
                    enews: args[:AMA__eNEWS],

--- a/spec/subscription_manager_spec.rb
+++ b/spec/subscription_manager_spec.rb
@@ -76,7 +76,6 @@ describe ExactTarget::SubscriptionManager do
     context 'exact target returns invalid response' do
       before(:each) do
         xml = "<exacttarget><system><subscriber></subscriber></system></exacttarget>"
-        # expect(RestClient).to receive(:post).at_least(:once).and_return(xml)
         WebMock::API.stub_request(:post, 'http://testurl/').to_return(body: xml, status: 200)
       end
 

--- a/spec/subscription_manager_spec.rb
+++ b/spec/subscription_manager_spec.rb
@@ -72,6 +72,19 @@ describe ExactTarget::SubscriptionManager do
         expect(subscription.associate_vehicle_reminder).to eq nil
       end
     end
+
+    context 'exact target returns invalid response' do
+      before(:each) do
+        xml = "<exacttarget><system><subscriber></subscriber></system></exacttarget>"
+        # expect(RestClient).to receive(:post).at_least(:once).and_return(xml)
+        WebMock::API.stub_request(:post, 'http://testurl/').to_return(body: xml, status: 200)
+      end
+
+      it 'creates basic subscription model' do
+        subscription = ExactTarget::SubscriptionManager.new.find('bruce_wayne@example.com')
+        expect(subscription.email).to eq 'bruce_wayne@example.com'
+      end
+    end
   end
 
   describe 'exists' do


### PR DESCRIPTION
Moved the fix into exact_target from this commit:
https://github.com/amaabca/my_ama/commit/a8eda5eb26e8022863baff63368e730
e7fac4121

That commit will be reverted in the change to upgrade exact_target on
my_ama because the error handling for the xml is now in exact_target.